### PR TITLE
Add a pre-commit to docs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,5 @@
 # yarn spellcheck-diff
 
 # yarn lint-staged
+
+yarn extension-cleanup

--- a/scripts/check-extension-cleanup.js
+++ b/scripts/check-extension-cleanup.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+const INJECTION_MARKER = '// AUTOMATICALLY GENERATED:';
+
+function checkMdxFiles() {
+  const mdxFiles = glob.sync('../**/*.mdx', { ignore: 'node_modules/**' });
+  let hasInjectedCode = false;
+
+  mdxFiles.forEach((file) => {
+    const content = fs.readFileSync(file, 'utf8');
+    if (content.includes(INJECTION_MARKER)) {
+      console.error(
+        `Error: File ${file} contains injected code from the Inline Snippets extension.`
+      );
+      hasInjectedCode = true;
+    }
+  });
+
+  if (hasInjectedCode) {
+    console.error(
+      'Please deactivate the Inline Snippets extension and remove all injected code before committing.'
+    );
+    process.exit(1);
+  } else {
+    console.log('No injected code found in MDX files.');
+    process.exit(0);
+  }
+}
+
+checkMdxFiles();


### PR DESCRIPTION
Adds a pre-commit to docs site, so that the remaining of the vs code extension work/preview do not leak into the repository.

- Allows for a script using the husky pre-commit hook. 
- Helps prevent the VS Code residue leaking to the docs site. 
 - When I was playing around, I was stuck with merge conflict, which should be avoidable using this husky pre-commit



### Warning: POC

Currently, this implementation is not optimized for production use case. The script goes through every mdx file, and looks if there is any remaining residue of the vs code extension code snippet preview. 

This should be in place, to have the docs repository be clutter free and not have to worry about the vs-code extension potentially causing merge conflicts.

### Potential Downside: 

If an engineer decides that they would like to have a supporting information or comments inside the code snippets. Like so: 
```
\`\`\`ts snippetPath="auth/signIn.ts"
// Some helpful comment
\`\`\`
```

This would be rejected. Currently the plugin itself won't honor any comment or supporting information within the backticks as well. 

## TODO: 

***Because this is an POC, there is no additional work for now, future improvement/optimization can be made to the script if it is accepted as a viable option***